### PR TITLE
[0.1] Resolved by comment

### DIFF
--- a/src/Models/Reports.php
+++ b/src/Models/Reports.php
@@ -85,6 +85,22 @@ class Reports extends BaseModel
     }
 
     /**
+     * Get comment that solve the report
+     *
+     * @return ReportsComments|null
+     */
+    public function getSolvedComment() : ?ReportsComments
+    {
+        return ReportsComments::findFirst([
+            'conditions' => 'reports_id = :report_id: AND is_solution = :is_solution: AND is_deleted = 0',
+            'bind' => [
+                'report_id' => $this->getId(),
+                'is_solution' => 1
+            ]
+        ]);
+    }
+
+    /**
      * Is this report solved?
      *
      * @return bool

--- a/tests/integration/CommentsCest.php
+++ b/tests/integration/CommentsCest.php
@@ -24,6 +24,7 @@ class CommentsCest
         $response = Comments::add($report, $comment, new Users(), true);
 
         $I->assertEquals($comment, $response->comment);
+        $I->assertEquals($response->getId(), $report->getSolvedComment()->getId());
     }
 
     public function removeComment(IntegrationTester $I) : void


### PR DESCRIPTION
### Overview
We need to be able to get the comments that resolve a report, also need to get the user that resolved the report in case that was a direct resolve without a comment.

### Resolve
Create a method on the model that get the resolved comment, without touching the relation user-report.